### PR TITLE
Bookshelves: backend fully connected

### DIFF
--- a/frontend/src/components/Bookshelf/Bookshelf.jsx
+++ b/frontend/src/components/Bookshelf/Bookshelf.jsx
@@ -130,8 +130,6 @@ const Bookshelf = () => {
   set this component to the active ID */
   function handleDragStart(event) {
     setActiveId(event.active.id);
-    // console.log("drag start: " + event.active.id);
-    // console.log("drag start: " + findContainer(event.active.id));
     setStartingShelf(findContainer(event.active.id));
   }
 
@@ -147,9 +145,6 @@ const Bookshelf = () => {
     // find the bookshelf container that they are in
     const activeContainer = findContainer(id);
     const overContainer = findContainer(overId);
-
-    // console.log('drag over, active container: ' + activeContainer);
-    // console.log('drag over, over container: ' + overContainer);
 
     // if there is no active, over, or if they do not collide
     // (i.e. no interaction being made, simply return)
@@ -209,9 +204,6 @@ const Bookshelf = () => {
     // find the bookshelf containers that they are in
     const activeContainer = findContainer(id);
     const overContainer = findContainer(overId);
-
-    // console.log("drag end active container: " + activeContainer);
-    // console.log("drag end active container: " + overContainer);
 
     // if there is no active, over, or if they are do not collide
     // (i.e. no interaction being made, simply return)

--- a/frontend/src/components/Bookshelf/Bookshelf.jsx
+++ b/frontend/src/components/Bookshelf/Bookshelf.jsx
@@ -28,6 +28,9 @@ const Bookshelf = () => {
     finishedList: [],
   });
 
+  // starting shelf for a book that is moved
+  const [startingShelf, setStartingShelf] = useState('');
+
   // runs when component mounts
   useEffect(() => {
     const fetchBookshelfData = async () => {
@@ -127,8 +130,9 @@ const Bookshelf = () => {
   set this component to the active ID */
   function handleDragStart(event) {
     setActiveId(event.active.id);
-    console.log("drag start: " + event.active.id);
-    console.log("drag start: " + findContainer(event.active.id));
+    // console.log("drag start: " + event.active.id);
+    // console.log("drag start: " + findContainer(event.active.id));
+    setStartingShelf(findContainer(event.active.id));
   }
 
   /* when user drags draggable over a droppable
@@ -144,8 +148,8 @@ const Bookshelf = () => {
     const activeContainer = findContainer(id);
     const overContainer = findContainer(overId);
 
-    console.log('drag over, active container: ' + activeContainer);
-    console.log('drag over, over container: ' + overContainer);
+    // console.log('drag over, active container: ' + activeContainer);
+    // console.log('drag over, over container: ' + overContainer);
 
     // if there is no active, over, or if they do not collide
     // (i.e. no interaction being made, simply return)
@@ -206,6 +210,9 @@ const Bookshelf = () => {
     const activeContainer = findContainer(id);
     const overContainer = findContainer(overId);
 
+    // console.log("drag end active container: " + activeContainer);
+    // console.log("drag end active container: " + overContainer);
+
     // if there is no active, over, or if they are do not collide
     // (i.e. no interaction being made, simply return)
     if (
@@ -219,6 +226,35 @@ const Bookshelf = () => {
     const activeIndex = items[activeContainer].findIndex(book => book.cover === active.id);
     const overIndex = items[overContainer].findIndex(book => book.cover === overId);
  
+    const endingShelf = activeContainer;
+    // if the shelves are different, insert at active index
+    console.log("drag end: ")
+    if (startingShelf != endingShelf) {
+      const bookToMove = items[endingShelf].find(book => book.cover === id);
+
+      console.log("book to move: ");
+      console.log(bookToMove);
+      console.log("ending shelf is: ");
+      console.log(endingShelf);
+      console.log("ending index is: ") ;
+      console.log(activeIndex);
+
+      // CALL DIANA API HERE using bookToMove, endingShelf, activeIndex
+    }
+    // if shelves are the same, insert at the over index
+    else {
+      const bookToMove = items[startingShelf].find(book => book.cover === id);
+
+      console.log("book to move: ");
+      console.log(bookToMove);
+      console.log("starting & ending shelf: ");
+      console.log(startingShelf);
+      console.log("ending index is: ");
+      console.log(overIndex);
+
+      // CALL DIANA API HERE using bookToMove, endingShelf, activeIndex
+    }
+    
     if (activeIndex !== overIndex) {
       setItems((items) => ({
         ...items,

--- a/frontend/src/components/Bookshelf/Bookshelf.jsx
+++ b/frontend/src/components/Bookshelf/Bookshelf.jsx
@@ -225,34 +225,58 @@ const Bookshelf = () => {
 
     const activeIndex = items[activeContainer].findIndex(book => book.cover === active.id);
     const overIndex = items[overContainer].findIndex(book => book.cover === overId);
- 
+
+    // update backend of book movement
     const endingShelf = activeContainer;
+
     // if the shelves are different, insert at active index
-    console.log("drag end: ")
+      // NOTE: this code inserts the book at the place it is *supposed* to be inserted
+      // -> in other words, it disregards the current visual bug where the book is inserted one index AFTER it is supposed to be
+      // -> ultimately, once that visual bug is fixed, this code will line up with visuals
     if (startingShelf != endingShelf) {
       const bookToMove = items[endingShelf].find(book => book.cover === id);
 
-      console.log("book to move: ");
-      console.log(bookToMove);
-      console.log("ending shelf is: ");
-      console.log(endingShelf);
-      console.log("ending index is: ") ;
-      console.log(activeIndex);
+      let bookData = {};
+      bookData.userId = localStorage.getItem("user_id").replace(/"/g, '');
+      bookData.bookId = bookToMove._id;
+      bookData.fromShelf = startingShelf === "readingList" ? "current" : "finished";
+      bookData.toShelf = endingShelf === "readingList" ? "current" : "finished";
+      bookData.newOrder = activeIndex;
 
-      // CALL DIANA API HERE using bookToMove, endingShelf, activeIndex
+      axios.post('http://localhost:5555/api/handlebooks/moveBook', { ...bookData }, {
+        headers: {
+            Authorization: localStorage.getItem("user_token")
+        }
+      })
+      .then(response => {
+          console.log("Book successfully moved across shelves: ", response.data);
+      })
+      .catch(error => {
+          console.error("Error moving book across shelves: ", error.response);
+      });
     }
     // if shelves are the same, insert at the over index
     else {
       const bookToMove = items[startingShelf].find(book => book.cover === id);
 
-      console.log("book to move: ");
-      console.log(bookToMove);
-      console.log("starting & ending shelf: ");
-      console.log(startingShelf);
-      console.log("ending index is: ");
-      console.log(overIndex);
+      let bookData = {};
+      bookData.userId = localStorage.getItem("user_id").replace(/"/g, '');
+      bookData.bookId = bookToMove._id;
+      bookData.fromShelf = startingShelf === "readingList" ? "current" : "finished";
+      bookData.toShelf = bookData.fromShelf;
+      bookData.newOrder = overIndex;
 
-      // CALL DIANA API HERE using bookToMove, endingShelf, activeIndex
+      axios.post('http://localhost:5555/api/handlebooks/moveBook', { ...bookData }, {
+        headers: {
+            Authorization: localStorage.getItem("user_token")
+        }
+      })
+      .then(response => {
+          console.log("Book successfully moved within the shelf: ", response.data);
+      })
+      .catch(error => {
+          console.error("Error moving book within the shelf: ", error.response);
+      });
     }
     
     if (activeIndex !== overIndex) {


### PR DESCRIPTION
This branch updates the backend when books move within the same shelf and between shelves.

**Things to note**
1. you can test using my account with user: kay45 and pass: kay45. BE CAREFUL though not to fully empty the bookshelves, because the backend will be updated properly, and since empty bookshelves aren't droppable, you would have to directly call API to populate it again. (if you accidentally do this just lmk and I can configure the account again)

2. (I mentioned this in comments as well, but...)
-> currently there's a bug where moving a book between two diff shelves results in the book being inserted at one index past where it is supposed to be (@kimcharlene is looking into it)
-> this code is not affected by that bug; it inserts the book where it's supposed to be in the DB. so once that visual bug is fixed, all will be good